### PR TITLE
Support for non-sentence_transformer models to be used in HF Embeddings

### DIFF
--- a/langchain/embeddings/huggingface.py
+++ b/langchain/embeddings/huggingface.py
@@ -35,8 +35,19 @@ class HuggingFaceEmbeddings(BaseModel, Embeddings):
         super().__init__(**kwargs)
         try:
             import sentence_transformers
-
-            self.client = sentence_transformers.SentenceTransformer(self.model_name)
+            try:
+                self.client = sentence_transformers.SentenceTransformer(self.model_name)
+            except:
+                try:
+                    # [Hugging Face Models can be converted into sentence_transformer models by adding a pooling layer](https://www.sbert.net/docs/training/overview.html#creating-networks-from-scratch)
+                    word_embedding_model = sentence_transformers.models.Transformer(self.model_name)
+                    pooling_model = sentence_transformers.models.Pooling(word_embedding_model.get_word_embedding_dimension())
+                    self.client = sentence_transformers.SentenceTransformer(modules=[word_embedding_model, pooling_model])
+                except ImportError:
+                    raise ValueError(
+                        "Model is not compatible sentence_transformers architecture. "
+                        "Please use a sentence_transformers model."
+                    )
         except ImportError:
             raise ValueError(
                 "Could not import sentence_transformers python package. "


### PR DESCRIPTION
[Hugging Face Models can be converted into sentence_transformer models by adding a pooling layer](https://www.sbert.net/docs/training/overview.html#creating-networks-from-scratch)